### PR TITLE
Support redacting yamls with nested keys

### DIFF
--- a/redact_it/redact_yaml.py
+++ b/redact_it/redact_yaml.py
@@ -2,6 +2,7 @@
 
 This module contains the core logic to redact data from yaml files.
 """
+import copy
 import glob
 from typing import Any
 
@@ -32,19 +33,20 @@ class RedactItYaml(RedactIt):
 
             try:
                 with open(file) as f:
-                    file_content: Any = self.yaml.load(f)
+                    file_content: dict[str, Any] = self.yaml.load(f)
             except FileNotFoundError as e:
                 print(f"Failed to load {file}, error: {e}")
                 continue
 
-            count: int = 0
+            file_changed: bool = False
 
-            for key, value in self.config.items():
-                if key in file_content and file_content[key] != value:
-                    file_content[key] = value
-                    count += 1
+            original_file_content = copy.copy(file_content)
+            file_content.update(self.config)
 
-            if count > 0:
+            if original_file_content != file_content:
+                file_changed = True
+
+            if file_changed:
                 if self.dry_run:
                     print(
                         f"File {file} would be redacted, disable --dry-run to redact it"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,14 @@ def asset_file() -> Iterator[str]:
     filename: str = "file1.yml"
     yaml = YAML()
     with open(filename, "w") as f:
-        yaml.dump({"foo": "bar", "secret": "secret-123"}, f)
+        yaml.dump(
+            {
+                "foo": "bar",
+                "secret": "secret-123",
+                "apple": {"recipe": "secret-recipe"},
+            },
+            f,
+        )
     yield filename
     os.remove(filename)
 
@@ -21,6 +28,9 @@ def config_file() -> Iterator[str]:
     filename: str = "redact-it.cfg"
     yaml = YAML()
     with open(filename, "w") as f:
-        yaml.dump({"secret": "redacted"}, f)
+        yaml.dump(
+            {"secret": "redacted", "apple": {"recipe": "redacted"}},
+            f,
+        )
     yield filename
     os.remove(filename)

--- a/tests/test_redact_it_yaml.py
+++ b/tests/test_redact_it_yaml.py
@@ -53,3 +53,4 @@ class TestRedactIt:
             file_content: dict[str, Any] = redact_it_yaml.yaml.load(f)
 
         assert file_content["secret"] == "redacted"
+        assert file_content["apple"]["recipe"] == "redacted"


### PR DESCRIPTION
# Description
Prior to this redact-it yaml only supported redacting key/value pairs that existed at one layer. This commit supports redacting nested key/value pairs.